### PR TITLE
tests: nightly: Fix and add more tests

### DIFF
--- a/tests/on_target/README.md
+++ b/tests/on_target/README.md
@@ -48,7 +48,7 @@ Run desired tests, example commands
 ```shell
 pytest -s -v -m "not slow" tests
 pytest -s -v -m "not slow" tests/test_functional/test_uart_output.py
-pytest -s -v -m "not slow" tests/test_functional/test_location.py::test_wifi_location
+pytest -s -v -m "not slow" tests/test_functional/test_sampling.py
 pytest -s -v -m "slow" tests/test_functional/test_fota.py::test_full_mfw_fota
 ```
 

--- a/tests/on_target/tests/test_functional/test_location.py
+++ b/tests/on_target/tests/test_functional/test_location.py
@@ -35,17 +35,28 @@ def run_location(t91x_board, hex_file, location_method):
         "Connected to Cloud"
     ]
 
-    patterns_location = ["Wi-Fi and cellular methods combined"] if location_method == "Wi-Fi" else []
-    patterns_location = patterns_location + [
-        "location_event_handler: Got location: lat:"]
+    # Log patterns
+    pattern_location = "location_event_handler: Got location: lat:"
+    pattern_shadow_poll = "Requesting device shadow from the device"
+    pattern_environmental = "Environmental values sample request received, getting data"
+    pattern_fota_poll = "Checking for FOTA job..."
+    pattern_battery = "State of charge:"
+
+    # Combine patterns for convenience
+    pattern_list = [
+        pattern_location,
+        pattern_shadow_poll,
+        pattern_environmental,
+        pattern_fota_poll,
+        pattern_battery
+    ]
 
     # Cloud connection
     t91x_board.uart.flush()
     reset_device()
-    t91x_board.uart.wait_for_str(patterns_cloud_connection, timeout=120)
 
-    # Location
-    t91x_board.uart.wait_for_str(patterns_location, timeout=180)
+    # Sampling
+    t91x_board.uart.wait_for_str(pattern_list, timeout=60)
 
     # Extract coordinates from UART output
     values = t91x_board.uart.extract_value( \

--- a/tests/on_target/tests/test_functional/test_sampling.py
+++ b/tests/on_target/tests/test_functional/test_sampling.py
@@ -14,20 +14,7 @@ from utils.logger import get_logger
 
 logger = get_logger()
 
-def test_wifi_location(t91x_board, hex_file):
-    '''
-    Test that the device can get location using Wi-Fi
-    '''
-    run_location(t91x_board, hex_file, location_method="Wi-Fi")
-
-@pytest.mark.skip(reason="GNSS location is not supported on this device")
-def test_gnss_location(t91x_board, hex_file):
-    '''
-    Test that the device can get location using GNSS
-    '''
-    run_location(t91x_board, hex_file, location_method="GNSS")
-
-def run_location(t91x_board, hex_file, location_method):
+def test_sampling(t91x_board, hex_file):
     flash_device(os.path.abspath(hex_file))
     t91x_board.uart.xfactoryreset()
     patterns_cloud_connection = [
@@ -64,6 +51,3 @@ def run_location(t91x_board, hex_file, location_method):
     assert values
     lat, lon, acc, method = values
     assert abs(float(lat) - 61.5) < 2 and abs(float(lon) - 10.5) < 1
-    method = int(method)
-    expected_method = 4 if location_method == "Wi-Fi" else 1
-    assert method == expected_method

--- a/tests/on_target/utils/uart.py
+++ b/tests/on_target/utils/uart.py
@@ -195,7 +195,7 @@ class Uart:
                 break
             if start_t + timeout < time.time():
                 raise AssertionError(
-                    f"{missing if missing else msgs} missing in UART log in the expected order. {error_msg}\nUart log:\n{self.log}"
+                    f"{missing if missing else msgs} missing in UART log in the expected order. {error_msg}"
                 )
             if self._evt.is_set():
                 raise RuntimeError(f"Uart thread stopped, log:\n{self.log}")
@@ -210,7 +210,7 @@ class Uart:
             if missing_msgs == []:
                 return self.get_size()
             if start_t + timeout < time.time():
-                raise AssertionError(f"{missing_msgs} missing in UART log. {error_msg}\nUart log:\n{self.log}")
+                raise AssertionError(f"{missing_msgs} missing in UART log. {error_msg}\n")
             if self._evt.is_set():
                 raise RuntimeError(f"Uart thread stopped, log:\n{self.log}")
             time.sleep(1)


### PR DESCRIPTION
Since cellular location method priority is no longer right after Wi-Fi, the location library will not combine Wi-Fi and cellular methods.

Due to this we need to update the test to not expect a combined location request.

Add additional checks to the same test to also verify that the device samples other sensor sources.